### PR TITLE
Exptype color

### DIFF
--- a/py/surveyqa/nightly.py
+++ b/py/surveyqa/nightly.py
@@ -213,47 +213,6 @@ def get_skypathplot(exposures, tiles, width=600, height=300):
     return fig
 
 
-def get_exptype_counts(exposures, calibs, width=300, height=300):
-    """
-    Generate a horizontal bar plot showing the counts for each type of
-    exposure grouped by whether they have FLAVOR='science' or PROGRAM='calib'
-
-    ARGS:
-        exposures : a table of exposures which only contain those with FLAVOR='science'
-        calibs : a table of exposures which only contains those with PROGRAm='calibs'
-    """
-    darks = len(exposures[exposures['PROGRAM'] == 'DARK'])
-    grays = len(exposures[exposures['PROGRAM'] == 'GRAY'])
-    brights = len(exposures[exposures['PROGRAM'] == 'BRIGHTS'])
-
-    arcs = len(calibs[calibs['FLAVOR'] == 'arc'])
-    flats = len(calibs[calibs['FLAVOR'] == 'flat'])
-    zeroes = len(calibs[calibs['FLAVOR'] == 'zero'])
-
-    types = [('calib', 'ZERO'), ('calib', 'FLAT'), ('calib', 'ARC'),
-            ('science', 'BRIGHT'), ('science', 'GRAY'), ('science', 'DARK')]
-    counts = np.array([zeroes, flats, arcs, brights, grays, darks])
-    COLORS = ['tan', 'orange', 'yellow', 'green', 'blue', 'red']
-
-    src = ColumnDataSource({'types':types, 'counts':counts})
-
-    p = bk.figure(width=width, height=height,
-                  y_range=FactorRange(*types), title='Exposure Type Counts',
-                  toolbar_location=None)
-    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white', 
-           fill_color=factor_cmap('types', palette=COLORS, factors=types), source=src)
-
-
-    labels = LabelSet(x='counts', y='types', text='counts', level='glyph', source=src,
-                      render_mode='canvas', x_offset=5, y_offset=-7,
-                      text_color='gray', text_font='tahoma', text_font_size='8pt')
-    p.add_layout(labels)
-
-    p.ygrid.grid_line_color=None
-
-    return p
-
-
 def overlaid_hist(all_exposures, night_exposures, attribute, color, width=300, height=150):
     """
     Generates an overlaid histogram for a single attribute comparing the distribution 
@@ -511,9 +470,9 @@ def makeplots(night, exposures, tiles, outdir):
 
 def get_exptype_counts(exposures, calibs, width=300, height=300):
     """
-    Generate a horizontal bar plot showing the counts for each type of exposure grouped 
-    by whether they have FLAVOR='science' or PROGRAM='calib'
-    
+    Generate a horizontal bar plot showing the counts for each type of
+    exposure grouped by whether they have FLAVOR='science' or PROGRAM='calib'
+
     ARGS:
         exposures : a table of exposures which only contain those with FLAVOR='science'
         calibs : a table of exposures which only contains those with PROGRAm='calibs'
@@ -521,31 +480,34 @@ def get_exptype_counts(exposures, calibs, width=300, height=300):
     darks = len(exposures[exposures['PROGRAM'] == 'DARK'])
     grays = len(exposures[exposures['PROGRAM'] == 'GRAY'])
     brights = len(exposures[exposures['PROGRAM'] == 'BRIGHTS'])
-    
+
     arcs = len(calibs[calibs['FLAVOR'] == 'arc'])
     flats = len(calibs[calibs['FLAVOR'] == 'flat'])
     zeroes = len(calibs[calibs['FLAVOR'] == 'zero'])
-    
-    types = [('calib', 'ZERO'), ('calib', 'FLAT'), ('calib', 'ARC'), 
+
+    types = [('calib', 'ZERO'), ('calib', 'FLAT'), ('calib', 'ARC'),
             ('science', 'BRIGHT'), ('science', 'GRAY'), ('science', 'DARK')]
     counts = np.array([zeroes, flats, arcs, brights, grays, darks])
-    
+    COLORS = ['tan', 'orange', 'yellow', 'green', 'blue', 'red']
+
     src = ColumnDataSource({'types':types, 'counts':counts})
-    
+
     p = bk.figure(width=width, height=height,
-                  y_range=FactorRange(*types), title='Exposure Type Counts', 
+                  y_range=FactorRange(*types), title='Exposure Type Counts',
                   toolbar_location=None)
-    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white',
-           fill_color=factor_cmap('types', palette=Spectral6, factors=types), source=src)
-    
-    
-    labels = LabelSet(x='counts', y='types', text='counts', level='glyph', source=src, 
-                      render_mode='canvas', x_offset=5, y_offset=-10, text_color='gray', text_font='sans-serif')
+    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white', 
+           fill_color=factor_cmap('types', palette=COLORS, factors=types), source=src)
+
+
+    labels = LabelSet(x='counts', y='types', text='counts', level='glyph', source=src,
+                      render_mode='canvas', x_offset=5, y_offset=-7,
+                      text_color='gray', text_font='tahoma', text_font_size='8pt')
     p.add_layout(labels)
-    
+
     p.ygrid.grid_line_color=None
-    
+
     return p
+
 
 def get_night_link(night, exposures):
     '''Gets the href string for the previous night and the next night for a given nightly page. 

--- a/py/surveyqa/nightly.py
+++ b/py/surveyqa/nightly.py
@@ -23,7 +23,7 @@ from datetime import tzinfo
 from datetime import datetime
 from bokeh.models.glyphs import HBar
 from bokeh.models import LabelSet, FactorRange
-from bokeh.palettes import Spectral6, viridis
+from bokeh.palettes import viridis
 from bokeh.transform import factor_cmap, factor_mark, linear_cmap
 from bokeh.models.widgets.tables import DataTable, TableColumn
     
@@ -233,14 +233,15 @@ def get_exptype_counts(exposures, calibs, width=300, height=300):
     types = [('calib', 'ZERO'), ('calib', 'FLAT'), ('calib', 'ARC'),
             ('science', 'BRIGHT'), ('science', 'GRAY'), ('science', 'DARK')]
     counts = np.array([zeroes, flats, arcs, brights, grays, darks])
+    COLORS = ['tan', 'orange', 'yellow', 'green', 'blue', 'red']
 
     src = ColumnDataSource({'types':types, 'counts':counts})
 
     p = bk.figure(width=width, height=height,
                   y_range=FactorRange(*types), title='Exposure Type Counts',
                   toolbar_location=None)
-    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white',
-           fill_color=factor_cmap('types', palette=Spectral6, factors=types), source=src)
+    p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white', 
+           fill_color=factor_cmap('types', palette=COLORS, factors=types), source=src)
 
 
     labels = LabelSet(x='counts', y='types', text='counts', level='glyph', source=src,


### PR DESCRIPTION
Updated the exptypeCounts barplot to match the colors on the summary page
Removed an unnecessary import from palettes to reflect this

Also, it seems to be deleting a duplicate version of the exptype counts plot which may have been added in the last merge with master...
That may produce issues with future pull requests if stuff gets moved around