### PR TITLE
silence harmless warnings

### DIFF
--- a/py/surveyqa/nightly.py
+++ b/py/surveyqa/nightly.py
@@ -28,6 +28,11 @@ from bokeh.transform import factor_cmap
 from bokeh.models.widgets.tables import DataTable, TableColumn
 from astropy import coordinates
 
+#- Avoid warnings from date & coord calculations in the future
+import warnings
+warnings.filterwarnings('ignore', 'ERFA function.*dubious year.*')
+warnings.filterwarnings('ignore', 'Tried to get polar motions for times after IERS data is valid.*')
+
 def find_night(exposures, night):
     """
     Generates a subtable of exposures corresponding to data from a single night N and adds column TIME

--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -21,7 +21,10 @@ import astropy.units as u
 
 from collections import Counter, OrderedDict
 
-
+#- Avoid warnings from date & coord calculations in the future
+import warnings
+warnings.filterwarnings('ignore', 'ERFA function.*dubious year.*')
+warnings.filterwarnings('ignore', 'Tried to get polar motions for times after IERS data is valid.*')
 
 def nights_first_observed(exposures, tiles):
     '''
@@ -104,7 +107,7 @@ def get_median(attribute, exposures):
     for n in list(OrderedDict(Counter(night)).keys()):
         exp_night = exposures[exposures['NIGHT'] == n]
         attrib = exp_night[attribute]
-        medians.append(np.median(attrib))
+        medians.append(np.ma.median(attrib))  #- use masked median
     
     return np.array(medians)
 


### PR DESCRIPTION
This PR silences 3 harmless warnings:
  * WARNING: ErfaWarning: ERFA function "d2dtf" yielded 1 of "dubious year (Note 5)" [astropy._erfa.core] -- from `astropy.time.Time.to_datetime()` not being able to predict leap seconds 5 years into the future (ok)
  * WARNING: Tried to get polar motions for times after IERS data is valid. -- from inability to predict the wobble of the earth's axis 5 years into the future (ok)
  * Warning: 'partition' will ignore the 'mask' of the MaskedColumn. -- from `np.median` working on `astropy.table.Table` columns that could potentially have masked values.  Replaced with the mask-aware `np.ma.median()` even though in this case (so far) no values actually were masked.

@ana-lyons, @rdoshi99, or @williyamshoe could you try running with this branch and confirm that you don't get any warnings with whatever versions of numpy and astropy you have installed?  I don't need all 3 of you to verify this, but it is good practice to have someone other than the original author double check, and it is useful for all of you to take a look at how to silence warnings that you don't need.

Other info: in this case I silenced specific warnings at the package-level because I wanted to get rid of every case of them without cluttering up the code.  This has the negative side effect that importing surveyqa will silence the ERFA and IERS warnings everywhere, including external to surveyqa, which may not be what the user intended if they were using this as a 3rd party dependency to their own code.  In this case we are self-contained so I think this is ok.  If this was a more general purpose library (like bokeh or numpy or astropy) we would want to only silence warnings at the specific places they occur in our code using something like:
```
import warnings
from astropy.utils.exceptions import AstropyUserWarning
...
with warnings.catch_warnings():
    warnings.simplefilter('ignore', AstropyUserWarning)
    # the single line of code generating the warning that we want to ignore

# proceed with other code, which could still generate warnings
```