### PR TITLE
Make summary page faster

### DIFF
--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -234,7 +234,8 @@ def nights_last_observed(exposures):
         return arr[len(arr)-1]
     return exposures.group_by("TILEID").groups.aggregate(last)
 
-tzone = TimezoneInfo(utc_offset = -7*u.hour)
+utc_offset = -7*u.hour
+tzone = TimezoneInfo(utc_offset = utc_offset)
 t1 = Time(58821, format='mjd', scale='utc')
 t = t1.to_datetime(timezone=tzone)
 
@@ -265,7 +266,9 @@ def get_progress(exposures, tiles, program):
 
     #- Convert MJD to list of datetimes for bokeh
     t1 = Time(finished_tiles['MJD'], format='mjd', scale='utc')
-    t = t1.to_datetime(timezone=tzone)
+    # t = t1.to_datetime(timezone=tzone)
+    # local non-timezone aware time, instead of much slower timezone aware
+    t = (t1 + utc_offset).to_datetime()
 
     #- Tile progress is just counting tiles
     tile_progress = np.arange(len(t))

--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -142,8 +142,6 @@ def get_median(attribute, exposures):
     '''
     medians = []
     for n in np.unique(exposures['NIGHT']):
-        # exp_night = exposures[exposures['NIGHT'] == n]
-        # attrib = exp_night[attribute]
         ii = (exposures['NIGHT'] == n)
         attrib = np.asarray(exposures[attribute])[ii]
         medians.append(np.ma.median(attrib))  #- use masked median
@@ -286,8 +284,8 @@ def get_surveyprogress_plot(progress, line_source, hover_follow, width=250, heig
     TODO: update docs for what "progress" is
 
     Args:
-        progress: dict keyed by DARK, GRAY, BRIGHT, with values 
-            (time, survey_progress, tile_progress) from get_progress    
+        progress: dict keyed by DARK, GRAY, BRIGHT, with values
+            (time, survey_progress, tile_progress) from get_progress
         line_source: line_source for the horizontal gray cursor-tracking line
         hover_follow: HoverTool object for the horizontal gray cursor-tracking line
 
@@ -368,8 +366,8 @@ def get_tileprogress_plot(progress, tiles, line_source, hover_follow, width=250,
     Generates a plot of survey progress (total tiles) vs. time
 
     Args:
-        progress: dict keyed by DARK, GRAY, BRIGHT, with values 
-            (time, survey_progress, tile_progress) from get_progress    
+        progress: dict keyed by DARK, GRAY, BRIGHT, with values
+            (time, survey_progress, tile_progress) from get_progress
         tiles: Table of tile locations with columns "TILEID", "PROGRAM"
         line_source: line_source for the horizontal gray cursor-tracking line
         hover_follow: HoverTool object for the horizontal gray cursor-tracking line
@@ -715,8 +713,6 @@ def get_expTimePerTile(exposures, width=250, height=250, min_border_left=50, min
             program: String of the desired program name
             color: Color of histogram
         '''
-        # a = exposures_nocalib.group_by("TILEID").groups.aggregate(sum_or_first)
-        # a = a[a["PROGRAM"] == program]
         thisprogram = (exposures_nocalib["PROGRAM"] == program)
         a = exposures_nocalib["TILEID", "EXPTIME"][thisprogram].group_by("TILEID").groups.aggregate(np.sum)
 

--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -699,11 +699,6 @@ def get_expTimePerTile(exposures, width=250, height=250, min_border_left=50, min
     fig.xaxis.major_label_orientation = np.pi/4
     fig.title.text_color = '#ffffff'
 
-    def sum_or_first(i):
-        if type(i[0]) is str:
-            return i[0]
-        return np.sum(i)
-
     def total_exptime_dgb(program, color):
         '''
         Adds a histogram to fig that correspond to the program of the argument with the color provided.

--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -140,9 +140,8 @@ def get_median(attribute, exposures):
     Output:
         returns a numpy array of the median values for each night
     '''
-    night = exposures['NIGHT']
     medians = []
-    for n in list(OrderedDict(Counter(night)).keys()):
+    for n in np.unique(exposures['NIGHT']):
         # exp_night = exposures[exposures['NIGHT'] == n]
         # attrib = exp_night[attribute]
         ii = (exposures['NIGHT'] == n)
@@ -160,45 +159,26 @@ def get_summarytable(exposures):
 
     Returns a bokeh DataTable object.
     '''
-    night = exposures['NIGHT']
-    sorted_total = OrderedDict(Counter(night))
-    night_exps_total = np.array(sorted_total.values())
-
-    #list of counts of each program for each night
-    # dct = []
-    # for n in list(sorted_total.keys()):
-    #     keep = exposures['NIGHT'] == n
-    #     nights_selected = exposures[keep]
-    #     program_freq = Counter(nights_selected['PROGRAM'])
-    #     dct.append(program_freq)
-    #
-    # #get the values out of the dictionaries above (in a specified order so we can splice later)
-    # counts = []
-    # for d in dct:
-    #     for key in ['BRIGHT', 'GRAY', 'DARK', 'CALIB']:
-    #         counts.append(d[key])
-    #
-    # #lists of counts of each program for each night
-    # brights = np.array([counts[i] for i in np.arange(0,len(counts), 4)])
-    # grays = np.array([counts[i] for i in np.arange(1,len(counts), 4)])
-    # darks = np.array([counts[i] for i in np.arange(2,len(counts), 4)])
-    # calibs = np.array([counts[i] for i in np.arange(3,len(counts), 4)])
+    nights = np.unique(exposures['NIGHT'])
 
     isbright = (exposures['PROGRAM'] == 'BRIGHT')
     isgray = (exposures['PROGRAM'] == 'GRAY')
     isdark = (exposures['PROGRAM'] == 'DARK')
     iscalib = (exposures['PROGRAM'] == 'CALIB')
 
-    brights = np.zeros(len(sorted_total))
-    grays = np.zeros(len(sorted_total))
-    darks = np.zeros(len(sorted_total))
-    calibs = np.zeros(len(sorted_total))
-    for i, n in enumerate(sorted_total.keys()):
+    num_nights = len(nights)
+    brights = list()
+    grays = list()
+    darks = list()
+    calibs = list()
+    totals = list()
+    for n in nights:
         thisnight = exposures['NIGHT'] == n
-        brights[i] = np.count_nonzero(thisnight & isbright)
-        grays[i] = np.count_nonzero(thisnight & isgray)
-        darks[i] = np.count_nonzero(thisnight & isdark)
-        calibs[i] = np.count_nonzero(thisnight & iscalib)
+        totals.append(np.count_nonzero(thisnight))
+        brights.append(np.count_nonzero(thisnight & isbright))
+        grays.append(np.count_nonzero(thisnight & isgray))
+        darks.append(np.count_nonzero(thisnight & isdark))
+        calibs.append(np.count_nonzero(thisnight & iscalib))
 
     med_air = get_median('AIRMASS', exposures)
     med_seeing = get_median('SEEING', exposures)
@@ -207,8 +187,8 @@ def get_summarytable(exposures):
     med_sky = get_median('SKY', exposures)
 
     source = ColumnDataSource(data=dict(
-        nights = list(OrderedDict(Counter(exposures['NIGHT'])).keys()),
-        totals = list(OrderedDict(Counter(exposures['NIGHT'])).values()),
+        nights = list(nights),
+        totals = totals,
         brights = brights,
         grays = grays,
         darks = darks,


### PR DESCRIPTION
This PR makes `surveyqa.summary.make_plots` ~2.7x faster from a variety of optimizations.  I'll add comments inline to explain the changes.

@ana-lyons @rdoshi99 @williyamshoe please take a look at these changes to understand what changed and why.  Visually they appear to produce identical output, though the summary.html files are *not* identical with master, though I haven't determined exactly what is different and why (maybe just rounding / timestamps?  maybe worse?  please double check me...)

On Monday we can discuss the tools I used to identify the hotspots for optimization.