### PR TITLE
made it easier to see label for exptype counts

### DIFF
--- a/py/surveyqa/nightly.py
+++ b/py/surveyqa/nightly.py
@@ -554,6 +554,7 @@ def get_exptype_counts(exposures, calibs, width=300, height=300, min_border_left
     src = ColumnDataSource({'types':types, 'counts':counts})
 
     p = bk.figure(width=width, height=height,
+                   x_range=(0, np.max(counts)*1.15),
                   y_range=FactorRange(*types), title='Exposure Type Counts',
                   toolbar_location=None, min_border_left=min_border_left, min_border_right=min_border_right)
     p.hbar(y='types', right='counts', left=0, height=0.5, line_color='white',


### PR DESCRIPTION
Just added one line, made the x_range dependent on the maximum count for the night *1.15 so that the label is always visible.