### PR TITLE
made colors on summary and nightly pages consistent

### DIFF
--- a/py/surveyqa/summary.py
+++ b/py/surveyqa/summary.py
@@ -784,7 +784,7 @@ def makeplots(exposures, tiles, outdir):
 
     .header {
         font-family: "Open Serif", Arial, Helvetica, sans-serif;
-        background-color: #f1f1f1;
+        background-color: #333;
         padding: 10px;
         text-align: left;
         justify: space-around;


### PR DESCRIPTION
I just made the title colors on the summary page consistent with the nightly page, so everything looks more uniform.